### PR TITLE
More docker tag var into circleci job not config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ jobs:
           paths:
             - ~/.m2
           key: tilkynna-build-lic-2-{{ checksum "pom.xml" }} -f pom-rat.xml
-      - run: | 
-          mvn clean -f pom-rat.xml license:check
+      - run: mvn clean -f pom-rat.xml license:check
+      - run: |
           DOCKER_TAG_mel=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
           echo "DOCKER_TAG_mel  is: $DOCKER_TAG_mel"
   docker-build:
@@ -83,7 +83,9 @@ jobs:
     working_directory: ~/build
     steps:
       - checkout
-      - run: echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
+      - run: |
+          DOCKER_TAG=0.8.3 
+          echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
   docker-build-push:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,10 @@ jobs:
           paths:
             - ~/.m2
           key: tilkynna-build-lic-2-{{ checksum "pom.xml" }} -f pom-rat.xml
-      - run: "mvn clean -f pom-rat.xml license:check"
+      - run: | 
+          "mvn clean -f pom-rat.xml license:check"
+          DOCKER_TAG_mel=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
+          echo "DOCKER_TAG_mel  is: $DOCKER_TAG_mel"
   docker-build:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
     working_directory: ~/build
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: "-Xmx3200m"      
-      DOCKER_TAG: 0.8.4 
+      MAVEN_OPTS: "-Xmx3200m"
     steps:
       - checkout
       - restore_cache:
@@ -82,6 +81,7 @@ jobs:
     steps:
       - checkout
       - run: |
+          DOCKER_TAG=branch-build 
           echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
   docker-build-push:
     docker:
@@ -90,6 +90,7 @@ jobs:
     steps:
       - checkout
       - run:|
+          DOCKER_TAG=0.8.3
           echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
   fossa-scan:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,6 @@ jobs:
             - ~/.m2
           key: tilkynna-build-lic-2-{{ checksum "pom.xml" }} -f pom-rat.xml
       - run: mvn clean -f pom-rat.xml license:check
-      - run: |
-          DOCKER_TAG_mel=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
-          echo "DOCKER_TAG_mel  is: $DOCKER_TAG_mel"
   docker-build:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             - ~/.m2
           key: tilkynna-build-lic-2-{{ checksum "pom.xml" }} -f pom-rat.xml
       - run: | 
-          "mvn clean -f pom-rat.xml license:check"
+          mvn clean -f pom-rat.xml license:check
           DOCKER_TAG_mel=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.6.0:exec)
           echo "DOCKER_TAG_mel  is: $DOCKER_TAG_mel"
   docker-build:
@@ -90,7 +90,8 @@ jobs:
     working_directory: ~/build
     steps:
       - checkout
-      - run: echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
+      - run:|
+          echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
   fossa-scan:
     docker:
       - image: golang:1.10.0-stretch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
     working_directory: ~/build
     environment:
       # Customize the JVM maximum heap limit
-      MAVEN_OPTS: "-Xmx3200m"
+      MAVEN_OPTS: "-Xmx3200m"      
+      DOCKER_TAG: 0.8.4 
     steps:
       - checkout
       - restore_cache:
@@ -81,7 +82,6 @@ jobs:
     steps:
       - checkout
       - run: |
-          DOCKER_TAG=0.8.3 
           echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
   docker-build-push:
     docker:

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>org.tilkynna</groupId>
 	<artifactId>tilkynna</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.8.3</version>
 	<packaging>jar</packaging>
 
 	<name>tilkynna</name>


### PR DESCRIPTION
This PR includes setting of the DOCKER_TAG variable within the circleci config rather than via an Environment Variable on job itself as: 
> - you cannot edit an environment variable on CircleCi you have to delete and add again
- having DOCKER_TAG as an environment variable has caused the build to overwrite a version when merging to master, THIS SHOULD NOT HAPPEN 
See build https://circleci.com/gh/GrindrodBank/tilkynna/179 ran docker push grindrodbank/tilkynna:0.8.0 
which overwrote version 0.8.0 on docker hub, that was originally pushed with build
https://circleci.com/gh/GrindrodBank/tilkynna/162