### PR TITLE
correct syntax error in `docker-build-push` section

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
     working_directory: ~/build
     steps:
       - checkout
-      - run:|
+      - run: |
           DOCKER_TAG=0.8.3
           echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
   fossa-scan:


### PR DESCRIPTION
relates to PR #18 `correct syntax error in `docker-build-push` section` which only happens on merge to master hence not picked up before. 