### PR TITLE
Tests need to run for jacoco/sonar-qube to pickup code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
       - run: |
          mvn clean
          mvn package \
-                -Dmaven.test.skip=true \
             org.jacoco:jacoco-maven-plugin:prepare-agent \
             sonar:sonar \
                 -Dsonar.host.url=https://sonarcloud.io \


### PR DESCRIPTION
This PR attempts to correct sonarqube showing 0% test coverage, when there are in fact tests within the code base. 

**See below TIlkynna Project shows 0% code coverage:** 
![image](https://user-images.githubusercontent.com/6588511/59177528-b3204780-8b5c-11e9-8c78-049578a82017.png)

Unfortunately we cannot see if this is taking effect until the analysis runs against master branch