### PR TITLE
Generate and push axios client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir ~/repo/tilkynna-typescript-axios
-      - run: /usr/local/bin/docker-entrypoint.sh generate -i ~/repo/doc/tilkynna_api.yaml -g typescript-axios -o ~/repo/tilkynna-typescript-axios --model-package=model --api-package=api --additional-properties=withSeparateModelsAndApi=true,modelPropertyNaming=camelCase,npmName=@grindrodbank/tilkynna-api
+      - run: /usr/local/bin/docker-entrypoint.sh generate -i ~/repo/doc/tilkynna_api.yml -g typescript-axios -o ~/repo/tilkynna-typescript-axios --model-package=model --api-package=api --additional-properties=withSeparateModelsAndApi=true,modelPropertyNaming=camelCase,npmName=@grindrodbank/tilkynna-api
       - persist_to_workspace:
           root: ~/repo
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,45 @@ jobs:
       - run: FOSSA_API_KEY=$FOSSA_API_KEY fossa analyze
       # Note: The 'fossa test' command must be run after the analyze command has been run, as it is dependent on the previous scan.
       - run: fossa test
+  generate-axios-client:
+    working_directory: ~/repo
+    docker:
+       - image: openapitools/openapi-generator-cli:latest
+    steps:
+      - checkout
+      - run: mkdir ~/repo/tilkynna-typescript-axios
+      - run: /usr/local/bin/docker-entrypoint.sh generate -i ~/repo/doc/tilkynna_api.yaml -g typescript-axios -o ~/repo/tilkynna-typescript-axios --model-package=model --api-package=api --additional-properties=withSeparateModelsAndApi=true,modelPropertyNaming=camelCase,npmName=@grindrodbank/tilkynna-api
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - tilkynna-typescript-axios
+
+  publish-axios-client:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:lts-jessie-browsers-legacy
+    steps:
+      - attach_workspace:
+          at: ~/repo/workspace
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@latest'
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/workspace/tilkynna-typescript-axios/.npmrc
+      - run:
+          name: Add node modules to the NPM ignore file.
+          command: echo 'node_modules/' >> ~/repo/workspace/tilkynna-typescript-axios/.npmignore
+      - run:
+          name: Run Yarn
+          command: cd ~/repo/workspace/tilkynna-typescript-axios && yarn
+      - run:
+          name: Build with Yarn
+          command: cd ~/repo/workspace/tilkynna-typescript-axios && yarn build
+      - run:
+          name: Publish to NPM with Yarn.
+          command: cd ~/repo/workspace/tilkynna-typescript-axios && yarn publish --access public
+
 workflows:
   version: 2
   build_test_and_push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,6 @@ jobs:
       - run: mvn clean -f pom-rat.xml license:check
   docker-build:
     machine: true
-    docker:
-      - image: docker:18.09
     working_directory: ~/build
     steps:
       - checkout
@@ -86,8 +84,6 @@ jobs:
           echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
   docker-build-push:
     machine: true
-    docker:
-      - image: docker:18.09
     working_directory: ~/build
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,9 +112,9 @@ jobs:
       - run: fossa test
 
   generate-axios-client:
-    working_directory: ~/repo
     docker:
        - image: openapitools/openapi-generator-cli:latest
+    working_directory: ~/repo
     steps:
       - checkout
       - run: mkdir ~/repo/tilkynna-typescript-axios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,9 @@ only-tags: &only-tags
       ignore: /.*/
 
 version: 2
-
 # NOTE: Several steps have been written to run in a machine executor
 # the main reason is that the maven build for sonarqube and unit tests
 # use [TestContainers](https://www.testcontainers.org/)
-
 jobs:
   static-analysis:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
           key: tilkynna-build-lic-2-{{ checksum "pom.xml" }} -f pom-rat.xml
       - run: mvn clean -f pom-rat.xml license:check
   docker-build:
+    machine: true
     docker:
       - image: docker:18.09
     working_directory: ~/build
@@ -84,6 +85,7 @@ jobs:
           DOCKER_TAG=branch-build 
           echo "running docker build script" && pwd && ./scripts/docker-build.sh $REPO $IMAGE_NAME $DOCKER_TAG
   docker-build-push:
+    machine: true
     docker:
       - image: docker:18.09
     working_directory: ~/build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ version: 2
 #executorType: machine
 jobs:
   static-analysis:
-    machine:
-      - image: maven:3.5.3-jdk-8-alpine
+    machine
     working_directory: ~/build
     environment:
       # Customize the JVM maximum heap limit
@@ -39,8 +38,7 @@ jobs:
       - store_artifacts:
           path:  target
   test:
-    machine:
-      - image: maven:3.5.3-jdk-8-alpine
+    machine
     working_directory: ~/build
     
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,14 @@
 # License MIT: https://opensource.org/licenses/MIT
 # **************************************************
 #
+
+only-tags: &only-tags
+  filters:
+    tags:
+      only: /^.*/
+    branches:
+      ignore: /.*/
+
 version: 2
 #executorType: machine
 jobs:
@@ -177,3 +185,31 @@ workflows:
             branches:
               only: master
       - generate-axios-client
+
+  tagged_build_push:
+    jobs:
+      - test: *only-tags
+      - static-analysis:
+          requires:
+          - test
+          <<: *only-tags
+      - license-headers: *only-tags
+      - fossa-scan: *only-tags
+      - generate-axios-client: *only-tags
+      - docker-build-push: *only-tags
+          requires:
+          - test
+          - static-analysis
+          - license-headers
+          - fossa-scan
+          - generate-axios-client
+          <<: *only-tags
+      - publish-axios-client:
+          requires:
+          - test
+          - static-analysis
+          - license-headers
+          - fossa-scan
+          - generate-axios-client
+          - docker-build-push
+          <<: *only-tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       - run: FOSSA_API_KEY=$FOSSA_API_KEY fossa analyze
       # Note: The 'fossa test' command must be run after the analyze command has been run, as it is dependent on the previous scan.
       - run: fossa test
+
   generate-axios-client:
     working_directory: ~/repo
     docker:
@@ -117,6 +118,7 @@ jobs:
     steps:
       - checkout
       - run: mkdir ~/repo/tilkynna-typescript-axios
+      - run: find /
       - run: /usr/local/bin/docker-entrypoint.sh generate -i ~/repo/doc/tilkynna_api.yaml -g typescript-axios -o ~/repo/tilkynna-typescript-axios --model-package=model --api-package=api --additional-properties=withSeparateModelsAndApi=true,modelPropertyNaming=camelCase,npmName=@grindrodbank/tilkynna-api
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 # **************************************************
 #
 version: 2
-executorType: machine
+#executorType: machine
 jobs:
   static-analysis:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 #executorType: machine
 jobs:
   static-analysis:
-    docker:
+    machine:
       - image: maven:3.5.3-jdk-8-alpine
     working_directory: ~/build
     environment:
@@ -39,7 +39,7 @@ jobs:
       - store_artifacts:
           path:  target
   test:
-    docker:
+    machine:
       - image: maven:3.5.3-jdk-8-alpine
     working_directory: ~/build
     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,8 +91,7 @@ jobs:
           DOCKER_TAG=0.8.3
           echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
   fossa-scan:
-    docker:
-      - image: golang:1.10.0-stretch
+    machine: true
     working_directory: ~/dokuti-build
     steps:
       # Install Fossa

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,9 @@ only-tags: &only-tags
       ignore: /.*/
 
 version: 2
-#executorType: machine
+# NOTE: Several steps have been written to run in a machine executor
+# the main reason is that the maven build for sonarqube and unit tests
+# use [TestContainers](https://www.testcontainers.org/)
 jobs:
   static-analysis:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          DOCKER_TAG=0.8.3
+          DOCKER_TAG=$CIRCLE_TAG
           echo "running docker build script" && pwd && ./scripts/docker-build-and-push.sh $REPO $IMAGE_NAME $DOCKER_TAG $DOCKER_REPO_HOST $DOCKER_USER $DOCKER_PASS
   fossa-scan:
     machine: true
@@ -173,19 +173,6 @@ workflows:
           - test
           - static-analysis
           - license-headers
-          filters:
-            branches:
-              ignore: master
-      - docker-build-push:
-          requires:
-          - test
-          - static-analysis
-          - license-headers
-          filters:
-            tags:
-              only: /^v*.*.*/
-            branches:
-              only: master
       - generate-axios-client
 
   tagged_build_push:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 #executorType: machine
 jobs:
   static-analysis:
-    machine
+    machine: true
     working_directory: ~/build
     environment:
       # Customize the JVM maximum heap limit
@@ -38,7 +38,7 @@ jobs:
       - store_artifacts:
           path:  target
   test:
-    machine
+    machine: true
     working_directory: ~/build
     
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ workflows:
       - license-headers: *only-tags
       - fossa-scan: *only-tags
       - generate-axios-client: *only-tags
-      - docker-build-push: *only-tags
+      - docker-build-push:
           requires:
           - test
           - static-analysis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
 
 workflows:
   version: 2
-  build_test_and_push:
+  untagged_build_and_test:
     jobs:
       - test
       - static-analysis
@@ -180,3 +180,4 @@ workflows:
               only: /^v*.*.*/
             branches:
               only: master
+      - generate-axios-client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
     steps:
       - checkout
       - run: mkdir ~/repo/tilkynna-typescript-axios
-      - run: find /
       - run: /usr/local/bin/docker-entrypoint.sh generate -i ~/repo/doc/tilkynna_api.yaml -g typescript-axios -o ~/repo/tilkynna-typescript-axios --model-package=model --api-package=api --additional-properties=withSeparateModelsAndApi=true,modelPropertyNaming=camelCase,npmName=@grindrodbank/tilkynna-api
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,6 @@ workflows:
       - static-analysis
       - fossa-scan:
           filters:
-            tags:
-              only: /^v*.*.*/
             branches:
               only: master
       - license-headers


### PR DESCRIPTION
This PR adds the CI capability to build the Axios typescript client package and to push to NPM if a release is tagged.

It adds two workflow steps to build and to push the package.
 
Builds happen on all commits,  but pushing to NPM only happens on tags.

**NOTES:**
* Trying to publish to an already published package version fails - by design: packages should be considered immutable.
* light-weight and annotated git tags fail on CircleCI - only Github releases work and are supported.
* machine executor explicitly specified for all steps configured to use it. New steps use docker executor.