### PR TITLE
Fix for extension installation fails with concurrent processes

### DIFF
--- a/src/main/resources/db/migration/postgresql/V0__include_pgcrypto_extension.sql
+++ b/src/main/resources/db/migration/postgresql/V0__include_pgcrypto_extension.sql
@@ -1,8 +1,9 @@
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT FROM pg_extension WHERE extname='pgcrypto') THEN
-    CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
-    COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
-  END IF;
+  CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+  COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+EXCEPTION
+  WHEN SQLSTATE '23505' THEN 
+	-- do nothing, the extension is already installed
 END; 
 $$


### PR DESCRIPTION
The `23505` SQL state exception occurs when concurrent processes try to `CREATE EXTENSION IF NOT EXISTS...` 
The addition of the exception handler for the case when the extension is installed concurrently, is the best way to manage the concurrent installation of the `pgcrypto` extension. 