### PR TITLE
Align docker-compose quickstart with a3 identity server changes

### DIFF
--- a/quickstart/docker-compose/docker-compose.yml
+++ b/quickstart/docker-compose/docker-compose.yml
@@ -88,8 +88,15 @@ services:
       - 80:80
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
+      - FLYWAY_ENABLE=true
+      - DATABASE_SERVER=a3s-postgresql
+      - DATABASE_NAME=identity_server
+      - DATABASE_PORT=5432
+      - FLYWAY_USER=postgres
+      - FLYWAY_PASSWORD=postgres
+      - FLYWAY_CONNECTION_RETRIES=5
     depends_on:
-      - a3s
+      - a3s-postgresql
 
   register-security-contract:
     networks:
@@ -104,8 +111,3 @@ services:
     
 networks:
   tilkynna-quickstart:
-  
-  
-  
-  
-          


### PR DESCRIPTION
The [latest A3S release](https://github.com/GrindrodBank/A3S/releases/tag/v1.1.0) introduces some environment variables that `a3s-identity-server` uses to configure startup behaviour.
(specifically [PR #104 - Move IDS4 migrations to IDS4 container](https://github.com/GrindrodBank/A3S/issues/104)).

This PR aligns the quickstart docker-compose with those changes.